### PR TITLE
[TASK] Allow more fine grained control of endpoint discovery

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Annotations/ExposeType.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Annotations/ExposeType.php
@@ -57,10 +57,28 @@ final class ExposeType
     public $subPackageKey = null;
 
     /**
+     * Each exposed object needs to be available through its resource URI, so having
+     * a controller in place is mandatory.
+     *
+     * This is the action name.
+     *
+     * @var string
+     */
+    public $actionName = 'index';
+
+    /**
      * Usually the action argument "$resource" is used. To name the input argument more
      * domain specific, this allows renaming.
      *
      * @var string
      */
     public $argumentName = 'resource';
+
+    /**
+     * Most exposed objects should be visible in endpoint discovery. But sometimes objects
+     * are only available through other objects. This flag hides them in endpoint discovery.
+     *
+     * @var bool
+     */
+    public $private = false;
 }

--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Configuration/ConfigurationProvider.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Configuration/ConfigurationProvider.php
@@ -51,9 +51,11 @@ class ConfigurationProvider
      */
     protected $defaultConfigurationSchema = [
         'argumentName' => '',
+        'actionName' => '',
         'controllerName' => '',
         'packageKey' => '',
         'subPackageKey' => null,
+        'private' => false,
         'attributesToBeApiExposed' => [],
         'relationshipsToBeApiExposed' => [],
     ];
@@ -127,7 +129,7 @@ class ConfigurationProvider
 
         /** @var JsonApi\ExposeType $annotation */
         foreach ($this->reflectionService->getClassAnnotations($type, JsonApi\ExposeType::class) as $annotation) {
-            foreach (['packageKey', 'subPackageKey', 'controllerName', 'argumentName'] as $setting) {
+            foreach (['packageKey', 'subPackageKey', 'controllerName', 'actionName', 'argumentName', 'private'] as $setting) {
                 if ((!array_key_exists($setting, $settings) || !$settings[$setting]) && $annotation->{$setting}) {
                     $settings[$setting] = $annotation->{$setting};
                 } elseif (!array_key_exists($setting, $settings)) {

--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Controller/EndpointDiscoveryController.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Controller/EndpointDiscoveryController.php
@@ -129,6 +129,9 @@ class EndpointDiscoveryController extends ActionController
             $uri = null;
             try {
                 $resource = $this->getDummyObject($className);
+                if ($this->configurationProvider->getSettingsForType($resource)['private']) {
+                    continue;
+                }
                 $type = $this->resourceMapper->getDataIdentifierForPayload($resource)['type'];
                 $uri = $this->buildUriForDummyResource($resource);
             } catch (FormatNotSupportedException $e) {}
@@ -183,7 +186,7 @@ class EndpointDiscoveryController extends ActionController
             ->setCreateAbsoluteUri(true);
 
         return $uriBuilder->uriFor(
-            'index',
+            $settings['actionName'],
             $controllerArguments,
             $settings['controllerName'],
             $settings['packageKey'],

--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Resource/GenericModelResourceInformation.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Resource/GenericModelResourceInformation.php
@@ -10,6 +10,7 @@ namespace Netlogix\JsonApiOrg\AnnotationGenerics\Domain\Resource;
  */
 
 use Netlogix\JsonApiOrg\AnnotationGenerics\Configuration\ConfigurationProvider;
+use Netlogix\JsonApiOrg\AnnotationGenerics\Controller\GenericModelController;
 use Netlogix\JsonApiOrg\AnnotationGenerics\Domain\Model\GenericModelInterface;
 use Netlogix\JsonApiOrg\Resource\Information\ResourceInformation;
 use Netlogix\JsonApiOrg\Resource\Information\ResourceInformationInterface;
@@ -65,7 +66,8 @@ class GenericModelResourceInformation extends ResourceInformation implements Res
             $settings['argumentName'] => $resource,
         ];
         $type = TypeHandling::getTypeForValue($resource);
-        if (preg_match(self::DOMAIN_MODEL_PATTERN, $type, $matches)) {
+        $controllerClassName = str_replace('.', '\\', $settings['packageKey'] . '\\Controller\\' . $settings['controllerName'] . 'Controller');
+        if (preg_match(self::DOMAIN_MODEL_PATTERN, $type, $matches) && class_exists($controllerClassName) && is_subclass_of($controllerClassName, GenericModelController::class)) {
             $result['subPackage'] = [];
             foreach (explode('\\', $matches['subPackage']) as $subPackage) {
                 $result['subPackage'][] = lcfirst($subPackage);


### PR DESCRIPTION
This allows using ApiController as base class for controllers and still use
annotation based endpoint discovery. The action name can now be specified.
Classes can be hidden from endpoint discovery while still being used normally.