### PR TITLE
Allow validaiton of intrfaces

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Controller/GenericModelController.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Controller/GenericModelController.php
@@ -176,10 +176,10 @@ class GenericModelController extends ApiController
     /**
      * @inheritdoc
      */
-    protected function mapRequestArgumentsToControllerArguments()
+    protected function initializeActionMethodArguments()
     {
+        parent::initializeActionMethodArguments();
         $this->determineResourceArgumentType();
-        parent::mapRequestArgumentsToControllerArguments();
     }
 
     /**
@@ -204,7 +204,10 @@ class GenericModelController extends ApiController
         /** @var Argument $newArgument */
         $newArgument = $this->objectManager->get(get_class($argumentTemplate), $argumentTemplate->getName(), $this->getModelClassNameForResourceType($typeValue));
         foreach (ObjectAccess::getSettablePropertyNames($newArgument) as $propertyName) {
-            ObjectAccess::setProperty($newArgument, $propertyName, ObjectAccess::getProperty($argumentTemplate, $propertyName));
+            $propertyValue = ObjectAccess::getProperty($argumentTemplate, $propertyName);
+            if ($propertyValue !== ObjectAccess::getProperty($newArgument, $propertyName)) {
+                ObjectAccess::setProperty($newArgument, $propertyName, $propertyValue);
+            }
         }
         $this->arguments['resource'] = $newArgument;
     }

--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Resource/GenericModelResource.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Resource/GenericModelResource.php
@@ -37,7 +37,9 @@ class GenericModelResource extends AbstractResource
     {
         $settings = $this->configurationProvider->getSettingsForType($this->getPayload());
         $this->attributesToBeApiExposed = $settings['attributesToBeApiExposed'];
+        ksort($this->attributesToBeApiExposed);
         $this->relationshipsToBeApiExposed = $settings['relationshipsToBeApiExposed'];
+        ksort($this->relationshipsToBeApiExposed);
         $this->identityAttributes = $settings['identityAttributes'];
     }
 


### PR DESCRIPTION
Argument validation is calculated based on the type of the argument. In case of interfaces as arguments there's no further information about those objects, so using the interface as source for the ConjunctionValidator is just fine. But in case of JsonApiOrg annotation generics, there's the $resourceType property, which means we do know enough about the actual target type to create a proper ConjunctionValidator.