### PR TITLE
TASK: The write model interface doesn't need to be executed

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Model/ReadModelInterface.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Model/ReadModelInterface.php
@@ -1,15 +1,12 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\AnnotationGenerics\Domain\Model;
 
 /*
- * This file is part of the Netlogix.JsonApiOrg.AnnotationGenerics package.
- *
- * This package is Open Source Software. For the full copyright and license
- * information, please view the LICENSE file which was distributed with this
- * source code.
+ * This interface doesn't provide any methods. It's sole purpose is to prevent
+ * write-only model objects to be shown and searched by the showAction() and
+ * showRelationshipAction().
  */
-
-use Neos\Flow\Annotations as Flow;
 
 interface ReadModelInterface extends GenericModelInterface
 {

--- a/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Model/WriteModelInterface.php
+++ b/Classes/Netlogix/JsonApiOrg/AnnotationGenerics/Domain/Model/WriteModelInterface.php
@@ -1,18 +1,12 @@
 <?php
+
 namespace Netlogix\JsonApiOrg\AnnotationGenerics\Domain\Model;
 
-/*
- * This file is part of the Netlogix.JsonApiOrg.AnnotationGenerics package.
- *
- * This package is Open Source Software. For the full copyright and license
- * information, please view the LICENSE file which was distributed with this
- * source code.
+/**
+ * This interface doesn't provide any methods. It's sole purpose is to prevent
+ * read-only model objects to be created by the createAction().
  */
-
-use Neos\Flow\Annotations as Flow;
-
 interface WriteModelInterface extends GenericModelInterface
 {
-    public function execute();
 
 }


### PR DESCRIPTION
Whoever wants an executable write model interface can happily use
that function. But the interface itself is only used to prevent
read-only  objects from fitting into the createAction(), just like
the read model interface is just there to prevent write-only objects
from fitting into the showAction().