### PR TITLE
FEATURE: Allow property mapping for child properties of filters

### DIFF
--- a/Classes/Controller/GenericModelController.php
+++ b/Classes/Controller/GenericModelController.php
@@ -187,7 +187,13 @@ class GenericModelController extends ApiController
     {
         $propertyMappingConfiguration = $this->arguments[$argumentName]->getPropertyMappingConfiguration();
         assert($propertyMappingConfiguration instanceof PropertyMappingConfiguration);
-        $propertyMappingConfiguration->allowAllProperties();
+
+        $propertyMappingConfiguration
+            ->allowAllProperties();
+
+        $propertyMappingConfiguration
+            ->forProperty(PropertyMappingConfiguration::PROPERTY_PATH_PLACEHOLDER)
+            ->allowAllProperties();
     }
 
     /**


### PR DESCRIPTION
Some filters aren't flat key=>value maps but have complex data
structures such as $filter[age][from].

This changes adds one level of allowed properties nesting.