### PR TITLE
BUGFIX: Use "@Flow\CompileStatic" to collect known types

### DIFF
--- a/Classes/Resource/Information/ExposableTypeMap.php
+++ b/Classes/Resource/Information/ExposableTypeMap.php
@@ -12,7 +12,9 @@ namespace Netlogix\JsonApiOrg\AnnotationGenerics\Resource\Information;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Log\PsrSystemLoggerInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Utility\TypeHandling;
 use Netlogix\JsonApiOrg\AnnotationGenerics\Annotations as JsonApi;
@@ -25,88 +27,67 @@ class ExposableTypeMap extends \Netlogix\JsonApiOrg\Resource\Information\Exposab
 {
 
     const PATTERN = '%^(?<vendor>[^\\\\]+)\\\\(?<package>[^\\\\]+)\\\\(?<subpackage>.+)?\\\\domain\\\\(?<type>model|command)\\\\(?<flat>.*)$%i';
+
     /**
-     * @var ReflectionService
      * @Flow\Inject
+     * @var ObjectManagerInterface
      */
-    public $reflectionService;
+    protected $objectManager;
+
     /**
-     * @var PackageManagerInterface
      * @Flow\Inject
+     * @var PsrSystemLoggerInterface
      */
-    protected $packageManager;
+    protected $psrSystemLoggerInterface;
 
     /**
      * All "ExposeType" objects are initialized automatically
      */
     public function initializeObject()
     {
-        foreach ($this->reflectionService->getClassNamesByAnnotation(JsonApi\ExposeType::class) as $className) {
-            foreach ($this->reflectionService->getClassAnnotations($className,
-                JsonApi\ExposeType::class) as $annotation) {
-                assert($annotation instanceof JsonApi\ExposeType);
-                $type = $annotation->typeName;
-                if (!$type) {
-                    $typeComponents = preg_split('%\\\\Domain\\\\(Model|Command)\\\\%i', $className, 2);
-                    $typeComponents[0] = explode('\\', $typeComponents[0]);
-                    while ($typeComponents[0] && !$this->packageManager->isPackageAvailable(join('.',
-                            $typeComponents[0]))) {
-                        unset($typeComponents[0][count($typeComponents[0]) - 1]);
-                    }
-                    $type = strtolower(end($typeComponents[0]) . '/' . str_replace('\\', '.', $typeComponents[1]));
+        list(
+            $oneToOneTypeToClassMap,
+            $classNameToPropertyNamesMap,
+            $classNamesToMethodNamesMap
+        ) = static::collectKnownTypes($this->objectManager);
+
+        $this->oneToOneTypeToClassMap = array_merge($this->oneToOneTypeToClassMap, $oneToOneTypeToClassMap);
+
+        foreach ($classNameToPropertyNamesMap as $className => $properties) {
+            foreach ($properties as $propertyName => $propertyVarType)
+                try {
+                    $this->registerKnownPropertyType(
+                        $oneToOneTypeToClassMap[$className],
+                        $propertyName,
+                        $propertyVarType
+                    );
+                } catch (\Exception $e) {
+                    $this->psrSystemLoggerInterface->error('Could not register known property type for type', [
+                        'className' => $className,
+                        'propertyName' => $propertyName,
+                        'propertyVarType' => $propertyVarType,
+                    ]);
                 }
-                $this->oneToOneTypeToClassMap[$className] = $type;
+        }
 
-                $propertyNames = $this
-                    ->reflectionService
-                    ->getPropertyNamesByAnnotation($className, JsonApi\ExposeProperty::class);
-                array_walk(
-                    $propertyNames,
-                    function (string $propertyName) use ($type, $className) {
-                        try {
-                            $this->registerKnownPropertyType(
-                                $type,
-                                $propertyName,
-                                $this
-                                    ->reflectionService
-                                    ->getPropertyTagValues($className, $propertyName, 'var')[0]
-                                    ?: ''
-                            );
-                        } catch (\Exception $e) {
-                        }
-                    }
-                );
-
-                $methodNames = $this
-                    ->reflectionService
-                    ->getMethodsAnnotatedWith($className, JsonApi\ExposeProperty::class);
-                array_walk(
-                    $methodNames,
-                    function (string $methodName) use ($type, $className) {
-                        $methodNameLength = strlen($methodName);
-                        if ($methodNameLength > 2 && substr($methodName, 0, 2) === 'is') {
-                            $propertyName = lcfirst(substr($methodName, 2));
-                        } elseif ($methodNameLength > 3 && (($methodNamePrefix = substr($methodName, 0, 3)) === 'get' || $methodNamePrefix === 'has')) {
-                            $propertyName = lcfirst(substr($methodName, 3));
-                        } else {
-                            return;
-                        }
-                        try {
-                            $this->registerKnownPropertyType(
-                                $type,
-                                $propertyName,
-                                $this
-                                    ->reflectionService
-                                    ->getMethodTagsValues($className, $methodName)['return'][0]
-                                    ?: ''
-                            );
-                        } catch (\Exception $e) {
-                        }
-                    }
-                );
-
+        foreach ($classNamesToMethodNamesMap as $className => $methods) {
+            foreach ($methods as $methodName => $methodVarType) {
+                try {
+                    $this->registerKnownPropertyType(
+                        $oneToOneTypeToClassMap[$className],
+                        $methodName,
+                        $methodVarType
+                    );
+                } catch (\Exception $e) {
+                    $this->psrSystemLoggerInterface->error('Could not register known property type for type', [
+                        'className' => $className,
+                        'methodName' => $methodName,
+                        'methodVarType' => $methodVarType,
+                    ]);
+                }
             }
         }
+
         parent::initializeObject();
     }
 
@@ -128,4 +109,79 @@ class ExposableTypeMap extends \Netlogix\JsonApiOrg\Resource\Information\Exposab
             $this->typeAndPropertyNameToClassIdentifierMap[$typeNameAndType] = $elementType;
         }
     }
+
+    /**
+     * This method is compiled statically, as the ReflectionService should not be used in Production context.
+     * The cached variant of the ReflectionService is missing at least the "methods annotated with".
+     *
+     * @Flow\CompileStatic
+     * @param ObjectManagerInterface $objectManager
+     * @return array
+     */
+    protected static function collectKnownTypes(ObjectManagerInterface $objectManager): array
+    {
+        $oneToOneTypeToClassMap = [];
+        $classNameToPropertyNamesMap = [];
+        $classNameToMethodNamesMap = [];
+
+        $reflectionService = $objectManager->get(ReflectionService::class);
+        $packageManager = $objectManager->get(PackageManager::class);
+
+        $exposedTypes = $reflectionService->getClassNamesByAnnotation(JsonApi\ExposeType::class);
+        foreach ($exposedTypes as $className) {
+            $annotations = $reflectionService->getClassAnnotations($className, JsonApi\ExposeType::class);
+
+            foreach ($annotations as $annotation) {
+                assert($annotation instanceof JsonApi\ExposeType);
+                $type = $annotation->typeName;
+
+                if (!$type) {
+                    $typeComponents = preg_split('%\\\\Domain\\\\(Model|Command)\\\\%i', $className, 2);
+                    $typeComponents[0] = explode('\\', $typeComponents[0]);
+                    while ($typeComponents[0] && !$packageManager->isPackageAvailable(join('.',
+                            $typeComponents[0]))) {
+                        unset($typeComponents[0][count($typeComponents[0]) - 1]);
+                    }
+                    $type = strtolower(end($typeComponents[0]) . '/' . str_replace('\\', '.', $typeComponents[1]));
+                }
+                $oneToOneTypeToClassMap[$className] = $type;
+                $classNameToPropertyNamesMap[$className] = [];
+                $classNameToMethodNamesMap[$className] = [];
+
+                $propertyNames = $reflectionService
+                    ->getPropertyNamesByAnnotation($className, JsonApi\ExposeProperty::class);
+                array_walk(
+                    $propertyNames,
+                    function (string $propertyName) use ($className, $reflectionService, &$classNameToPropertyNamesMap) {
+                        $classNameToPropertyNamesMap[$className][$propertyName] = $reflectionService
+                            ->getPropertyTagValues($className, $propertyName, 'var')[0]
+                            ?: '';
+                    }
+                );
+
+                $methodNames = $reflectionService
+                    ->getMethodsAnnotatedWith($className, JsonApi\ExposeProperty::class);
+                array_walk(
+                    $methodNames,
+                    function (string $methodName) use ($className, $reflectionService, &$classNameToMethodNamesMap) {
+                        $methodNameLength = strlen($methodName);
+                        if ($methodNameLength > 2 && substr($methodName, 0, 2) === 'is') {
+                            $propertyName = lcfirst(substr($methodName, 2));
+                        } elseif ($methodNameLength > 3 && (($methodNamePrefix = substr($methodName, 0, 3)) === 'get' || $methodNamePrefix === 'has')) {
+                            $propertyName = lcfirst(substr($methodName, 3));
+                        } else {
+                            return;
+                        }
+
+                        $classNameToMethodNamesMap[$className][$propertyName] = $reflectionService
+                            ->getMethodTagsValues($className, $methodName)['return'][0]
+                            ?: '';
+                    }
+                );
+            }
+        }
+
+        return [$oneToOneTypeToClassMap, $classNameToPropertyNamesMap, $classNameToMethodNamesMap];
+    }
+
 }


### PR DESCRIPTION
Flow's ReflectionService should not be used while Flow is running
in Production context. Exposed types and properties / methods are
now collected during compile time. This way we don't have to
rely on the ReflectionService after the classes were compiled