### PR TITLE
BUGFIX: ExtraLazyPersistentCollection::matching() returns self

### DIFF
--- a/Classes/Doctrine/ExtraLazyPersistentCollection.php
+++ b/Classes/Doctrine/ExtraLazyPersistentCollection.php
@@ -62,6 +62,9 @@ class ExtraLazyPersistentCollection extends AbstractLazyCollection implements Se
         );
     }
 
+    /**
+     * @return self
+     */
     public function matching(Criteria $criteria): Collection
     {
         return new self(


### PR DESCRIPTION
The concept of extralazy persistent collections is being chainable through multiple calls of "matching", narrowing down the result set with each step. This means ExtraLazyPersistentCollection::matching() returns another ExtraLazyPersistentCollection, not a plain Collection like parent::matching() does.