### PR TITLE
fix: Properly clone request arguments

### DIFF
--- a/Classes/Controller/GenericModelController.php
+++ b/Classes/Controller/GenericModelController.php
@@ -369,8 +369,9 @@ class GenericModelController extends ApiController
             $argumentTemplate->getName(),
             $modelClassName
         );
+        assert($newArgument instanceof Argument);
 
-        $this->arguments[$argumentName] = $newArgument;
+        $this->arguments[$argumentName] = $this->cloneActionArgument($argumentTemplate, $newArgument);
     }
 
     protected function cloneActionArgument($argumentTemplate, Argument $newArgument)


### PR DESCRIPTION
Otherwise properties like "mapRequestArguments" are lost.