### PR TITLE
fix: Remove invalid semicolon from dummy object serialized string

### DIFF
--- a/Classes/Controller/EndpointDiscoveryController.php
+++ b/Classes/Controller/EndpointDiscoveryController.php
@@ -207,7 +207,7 @@ class EndpointDiscoveryController extends ActionController
      */
     protected function getDummyObject(string $className)
     {
-        return unserialize('O:' . strlen($className) . ':"' . $className . '":0:{};');
+        return unserialize('O:' . strlen($className) . ':"' . $className . '":0:{}');
     }
 
     /**


### PR DESCRIPTION
unserialize() emits a E_WARNING if the input contains unconsumed bytes since PHP 8.3.

The semicolon was not used before anyway.