### PR TITLE
feat: Avoid xand composite clause with only one child expression

### DIFF
--- a/Classes/Doctrine/ExtraLazyPersistentCollection.php
+++ b/Classes/Doctrine/ExtraLazyPersistentCollection.php
@@ -91,10 +91,13 @@ class ExtraLazyPersistentCollection extends AbstractLazyCollection implements Se
             $cloneData[$getter] = array_filter($cloneData[$getter]);
         }
 
+        $getWhereExpression = match(count($cloneData['getWhereExpression'])) {
+            0 => null,
+            1 => array_shift($cloneData['getWhereExpression']),
+            default => Criteria::expr()->andX(... $cloneData['getWhereExpression'])
+        };
         return new Criteria(
-            $cloneData['getWhereExpression']
-                ? Criteria::expr()->andX(... $cloneData['getWhereExpression'])
-                : null,
+            $getWhereExpression,
             array_shift($cloneData['getOrderings']),
             array_shift($cloneData['getFirstResult']),
             array_shift($cloneData['getMaxResults'])


### PR DESCRIPTION
The extra lazy collection used to wrap its where clause in XAND expressions for every subsequent "getCriteria()", which resulted in a couple of layers of AND calculations, usually only having a single EQUALS comparison.

This change only wraps multipe WHERE expressions into an XOR cluase and uses the existing clause "as is" if there's only one condition.