### PR TITLE
fix: Prevent show requests from validating known objects

### DIFF
--- a/Classes/Controller/GenericModelController.php
+++ b/Classes/Controller/GenericModelController.php
@@ -356,7 +356,7 @@ class GenericModelController extends ApiController
             : null;
 
         $this->remapActionArgument(
-            'resource',
+            $this->resourceArgumentName,
             $exposableType->className
         );
 
@@ -486,15 +486,15 @@ class GenericModelController extends ApiController
                             $this->request->getHttpRequest()->getUploadedFiles()
                         );
                     }
-                    if ($argumentName === 'resource' && array_keys($body) === ['resource']) {
+                    if ($argumentName === $this->resourceArgumentName && array_keys($body) === [$this->resourceArgumentName]) {
                         // Backwards compatibility for old-style resource requests
-                        $body = $body['resource'];
+                        $body = $body[$this->resourceArgumentName];
                     }
 
                     $argument->setValue($body);
                 } elseif ($this->request->hasArgument($argumentName)) {
                     $argumentValue = $this->request->getArgument($argumentName);
-                    if ($argumentName === 'resource'
+                    if ($argumentName === $this->resourceArgumentName
                         && is_string($argumentValue)
                         && is_a($argument->getDataType(), ReadModelInterface::class, true)
                     ) {


### PR DESCRIPTION
If a single object is to be displayed which is referenced by its string
primary key, there's no reason for it to pass through the validation
pipeline.

This primarily prevents show requests from loading arbitrary properties
that might not be API-exposed and not even meant to be accessed at all
in a web request, hence improving memory optimization — such as, for
example, large collections.